### PR TITLE
Adding plans

### DIFF
--- a/librosclub-backend/src/controllers/clubsController.js
+++ b/librosclub-backend/src/controllers/clubsController.js
@@ -8,6 +8,18 @@ async function getMiRol(userId, clubId) {
   return rows[0]?.rol ?? null;
 }
 
+async function isPremiumClub(clubId) {
+  const { rows } = await pool.query(
+    'SELECT plan, plan_expires_at FROM public.clubs WHERE id = $1',
+    [clubId]
+  );
+  if (!rows.length) return null;
+  const { plan, plan_expires_at } = rows[0];
+  if (plan !== 'premium') return false;
+  if (plan_expires_at && new Date(plan_expires_at) < new Date()) return false;
+  return true;
+}
+
 exports.getClubs = async (req, res) => {
   const userId = req.user?.userId ?? null;
   try {
@@ -26,7 +38,9 @@ exports.getClubs = async (req, res) => {
          MAX(CASE WHEN cm.usuario_id = $1 THEN cm.rol END) AS "miRol",
          c.current_book_title     AS "currentBookTitle",
          c.current_book_author    AS "currentBookAuthor",
-         c.current_book_cover_url AS "currentBookCoverUrl"
+         c.current_book_cover_url AS "currentBookCoverUrl",
+         c.plan,
+         c.plan_expires_at        AS "planExpiresAt"
        FROM public.clubs c
        JOIN public.users u ON u.id = c.creador_id
        LEFT JOIN public.club_members cm ON cm.club_id = c.id
@@ -74,6 +88,8 @@ exports.createClub = async (req, res) => {
       currentBookTitle: null,
       currentBookAuthor: null,
       currentBookCoverUrl: null,
+      plan: 'free',
+      planExpiresAt: null,
     });
   } catch (err) {
     await client.query('ROLLBACK');
@@ -88,6 +104,21 @@ exports.joinClub = async (req, res) => {
   const userId = req.user.userId;
   const { id: clubId } = req.params;
   try {
+    const premium = await isPremiumClub(clubId);
+    if (premium === null) return res.status(404).json({ message: 'Club no encontrado.' });
+    if (!premium) {
+      const { rows: countRows } = await pool.query(
+        'SELECT COUNT(*) FROM public.club_members WHERE club_id = $1',
+        [clubId]
+      );
+      if (parseInt(countRows[0].count) >= 10) {
+        return res.status(403).json({
+          message: 'Este club está lleno (máx. 10 miembros en plan gratuito).',
+          code: 'MEMBERS_LIMIT_REACHED',
+        });
+      }
+    }
+
     const { rows } = await pool.query(
       `INSERT INTO public.club_members (usuario_id, club_id, rol)
        VALUES ($1, $2, 'miembro')
@@ -143,7 +174,9 @@ exports.getClubDetail = async (req, res) => {
               MAX(CASE WHEN cm.usuario_id = $1 THEN cm.rol END) AS "miRol",
               c.current_book_title     AS "currentBookTitle",
               c.current_book_author    AS "currentBookAuthor",
-              c.current_book_cover_url AS "currentBookCoverUrl"
+              c.current_book_cover_url AS "currentBookCoverUrl",
+              c.plan,
+              c.plan_expires_at        AS "planExpiresAt"
        FROM public.clubs c
        JOIN public.users u ON u.id = c.creador_id
        LEFT JOIN public.club_members cm ON cm.club_id = c.id
@@ -189,6 +222,11 @@ exports.setCurrentBook = async (req, res) => {
     return res.status(403).json({ message: 'Solo el admin del club puede cambiar el libro actual.' });
   }
 
+  const premium = await isPremiumClub(clubId);
+  if (!premium) {
+    return res.status(403).json({ message: 'Esta función requiere plan Premium.', code: 'PREMIUM_REQUIRED' });
+  }
+
   const { title, author, coverUrl } = req.body;
   try {
     await pool.query(
@@ -212,6 +250,11 @@ exports.addMeeting = async (req, res) => {
   const miRol = await getMiRol(userId, clubId);
   if (miRol !== 'admin' && !isGlobalAdmin) {
     return res.status(403).json({ message: 'Solo el admin del club puede agregar reuniones.' });
+  }
+
+  const premium = await isPremiumClub(clubId);
+  if (!premium) {
+    return res.status(403).json({ message: 'Esta función requiere plan Premium.', code: 'PREMIUM_REQUIRED' });
   }
 
   const { titulo, fecha, ubicacion, descripcion } = req.body;
@@ -243,6 +286,11 @@ exports.deleteMeeting = async (req, res) => {
     return res.status(403).json({ message: 'Solo el admin del club puede eliminar reuniones.' });
   }
 
+  const premium = await isPremiumClub(clubId);
+  if (!premium) {
+    return res.status(403).json({ message: 'Esta función requiere plan Premium.', code: 'PREMIUM_REQUIRED' });
+  }
+
   try {
     await pool.query('DELETE FROM public.club_meetings WHERE id = $1 AND club_id = $2', [meetingId, clubId]);
     res.json({ message: 'Reunión eliminada.' });
@@ -260,6 +308,11 @@ exports.createPost = async (req, res) => {
   const miRol = await getMiRol(userId, clubId);
   if (!miRol && !isGlobalAdmin) {
     return res.status(403).json({ message: 'Debés ser miembro del club para postear.' });
+  }
+
+  const premium = await isPremiumClub(clubId);
+  if (!premium) {
+    return res.status(403).json({ message: 'Esta función requiere plan Premium.', code: 'PREMIUM_REQUIRED' });
   }
 
   const { contenido } = req.body;
@@ -285,6 +338,11 @@ exports.deletePost = async (req, res) => {
   const userId = req.user.userId;
   const isGlobalAdmin = req.user.role === 'admin';
   const { id: clubId, postId } = req.params;
+
+  const premium = await isPremiumClub(clubId);
+  if (!premium) {
+    return res.status(403).json({ message: 'Esta función requiere plan Premium.', code: 'PREMIUM_REQUIRED' });
+  }
 
   try {
     const { rows } = await pool.query(
@@ -325,6 +383,8 @@ exports.getNearbyClubs = async (req, res) => {
          c.current_book_title     AS "currentBookTitle",
          c.current_book_author    AS "currentBookAuthor",
          c.current_book_cover_url AS "currentBookCoverUrl",
+         c.plan,
+         c.plan_expires_at        AS "planExpiresAt",
          (6371 * acos(LEAST(1.0,
            cos(radians($1::float)) * cos(radians(c.lat)) * cos(radians(c.lng) - radians($2::float)) +
            sin(radians($1::float)) * sin(radians(c.lat))
@@ -345,6 +405,31 @@ exports.getNearbyClubs = async (req, res) => {
   } catch (err) {
     console.error('getNearbyClubs:', err);
     res.status(500).json({ message: 'Error al buscar clubes cercanos.' });
+  }
+};
+
+exports.upgradeClub = async (req, res) => {
+  const userId = req.user.userId;
+  const isGlobalAdmin = req.user.role === 'admin';
+  const { id: clubId } = req.params;
+
+  const miRol = await getMiRol(userId, clubId);
+  if (miRol !== 'admin' && !isGlobalAdmin) {
+    return res.status(403).json({ message: 'Solo el admin del club puede actualizar el plan.' });
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `UPDATE public.clubs
+       SET plan = 'premium', plan_expires_at = NOW() + INTERVAL '30 days'
+       WHERE id = $1
+       RETURNING plan, plan_expires_at AS "planExpiresAt"`,
+      [clubId]
+    );
+    res.json({ message: 'Club actualizado a Premium.', ...rows[0] });
+  } catch (err) {
+    console.error('upgradeClub:', err);
+    res.status(500).json({ message: 'Error al actualizar el plan.' });
   }
 };
 

--- a/librosclub-backend/src/routes/auth.js
+++ b/librosclub-backend/src/routes/auth.js
@@ -1,8 +1,15 @@
 const express = require('express');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
-const pool = require('../config/db'); // Configuración de la base de datos
+const pool = require('../config/db');
+const authMiddleware = require('../middlewares/authMiddleware');
 const router = express.Router();
+
+function effectivePlan(userData) {
+  if (userData.plan !== 'premium') return 'free';
+  if (userData.plan_expires_at && new Date(userData.plan_expires_at) < new Date()) return 'free';
+  return 'premium';
+}
 
 router.post('/login', async (req, res) => {
   const { username, password } = req.body;
@@ -24,8 +31,9 @@ router.post('/login', async (req, res) => {
       return res.status(401).json({ message: 'Credenciales inválidas.' });
     }
 
+    const plan = effectivePlan(userData);
     const token = jwt.sign(
-      { userId: userData.id, username: userData.username, role: userData.role },
+      { userId: userData.id, username: userData.username, role: userData.role, plan },
       process.env.JWT_SECRET,
       { expiresIn: '7d' }
     );
@@ -57,7 +65,7 @@ router.post('/register', async (req, res) => {
     );
     const user = result.rows[0];
     const token = jwt.sign(
-      { userId: user.id, username: user.username, role: user.role },
+      { userId: user.id, username: user.username, role: user.role, plan: 'free' },
       process.env.JWT_SECRET,
       { expiresIn: '7d' }
     );
@@ -65,6 +73,27 @@ router.post('/register', async (req, res) => {
   } catch (err) {
     console.error('register:', err);
     res.status(500).json({ message: 'Error del servidor.' });
+  }
+});
+
+router.put('/upgrade', authMiddleware, async (req, res) => {
+  const userId = req.user.userId;
+  try {
+    await pool.query(
+      `UPDATE public.users SET plan = 'premium', plan_expires_at = NOW() + INTERVAL '30 days' WHERE id = $1`,
+      [userId]
+    );
+    const userRow = await pool.query('SELECT * FROM public.users WHERE id = $1', [userId]);
+    const userData = userRow.rows[0];
+    const newToken = jwt.sign(
+      { userId: userData.id, username: userData.username, role: userData.role, plan: 'premium' },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+    res.json({ token: newToken });
+  } catch (err) {
+    console.error('upgrade user:', err);
+    res.status(500).json({ message: 'Error al actualizar el plan.' });
   }
 });
 

--- a/librosclub-backend/src/routes/clubs.js
+++ b/librosclub-backend/src/routes/clubs.js
@@ -5,7 +5,7 @@ const optionalAuth = require('../middlewares/optionalAuth');
 const {
   getClubs, createClub, joinClub, leaveClub,
   getClubDetail, setCurrentBook, addMeeting, deleteMeeting, createPost, deletePost,
-  getNearbyClubs, setClubLocation,
+  getNearbyClubs, setClubLocation, upgradeClub,
 } = require('../controllers/clubsController');
 
 router.get('/',                           optionalAuth, getClubs);
@@ -16,6 +16,7 @@ router.delete('/:id/leave',              authMiddleware, leaveClub);
 router.get('/:id',                        authMiddleware, getClubDetail);
 router.put('/:id/current-book',           authMiddleware, setCurrentBook);
 router.put('/:id/location',               authMiddleware, setClubLocation);
+router.put('/:id/upgrade',                authMiddleware, upgradeClub);
 router.post('/:id/meetings',              authMiddleware, addMeeting);
 router.delete('/:id/meetings/:meetingId', authMiddleware, deleteMeeting);
 router.post('/:id/posts',                 authMiddleware, createPost);

--- a/librosclub-frontend/src/components/ClubDetailSheet.tsx
+++ b/librosclub-frontend/src/components/ClubDetailSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Club, ClubDetail, ClubMeeting, ClubPost, clubsAPI } from '../utils/api';
+import { Club, ClubDetail, ClubMeeting, ClubPost, clubsAPI, ApiError } from '../utils/api';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
@@ -8,7 +8,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { motion, AnimatePresence } from 'framer-motion';
-import { BookOpen, Calendar, MapPin, Users, Trash2, Send, Navigation } from 'lucide-react';
+import { BookOpen, Calendar, MapPin, Users, Trash2, Send, Navigation, Crown, Sparkles } from 'lucide-react';
 
 interface Props {
   club: Club;
@@ -40,6 +40,34 @@ function timeAgo(iso: string) {
   return `hace ${diffDays} día${diffDays > 1 ? 's' : ''}`;
 }
 
+const UpgradeBanner: React.FC<{
+  isAdmin: boolean;
+  onUpgrade: () => void;
+  isUpgrading: boolean;
+}> = ({ isAdmin, onUpgrade, isUpgrading }) => (
+  <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 space-y-2">
+    <div className="flex items-center gap-2">
+      <Sparkles className="h-4 w-4 text-amber-600 flex-shrink-0" />
+      <p className="text-sm font-mono font-bold text-amber-800">Función Premium</p>
+    </div>
+    <p className="text-xs text-amber-700">
+      El libro actual, las reuniones y el foro son exclusivos del plan Premium.
+      {isAdmin ? ' Actualizá tu club para desbloquearlos.' : ' El admin del club puede actualizarlo.'}
+    </p>
+    {isAdmin && (
+      <Button
+        size="sm"
+        onClick={onUpgrade}
+        disabled={isUpgrading}
+        className="bg-amber-600 hover:bg-amber-700 text-white text-xs h-8 mt-1"
+      >
+        <Crown className="h-3.5 w-3.5 mr-1.5" />
+        {isUpgrading ? 'Actualizando...' : 'Activar Premium (demo)'}
+      </Button>
+    )}
+  </div>
+);
+
 const ClubDetailSheet: React.FC<Props> = ({ club, token, userId, onClose, onClubUpdated }) => {
   const [detail, setDetail] = useState<ClubDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -69,8 +97,12 @@ const ClubDetailSheet: React.FC<Props> = ({ club, token, userId, onClose, onClub
   const [isPosting, setIsPosting] = useState(false);
   const [deletingPostId, setDeletingPostId] = useState<number | null>(null);
 
+  // Plan
+  const [isUpgrading, setIsUpgrading] = useState(false);
+
   const { toast } = useToast();
   const isClubAdmin = detail?.miRol === 'admin';
+  const isPremium = detail?.plan === 'premium';
 
   useEffect(() => {
     setIsLoading(true);
@@ -79,6 +111,20 @@ const ClubDetailSheet: React.FC<Props> = ({ club, token, userId, onClose, onClub
       .catch((err: any) => toast({ title: 'Error', description: err.message, variant: 'destructive' }))
       .finally(() => setIsLoading(false));
   }, [club.id, token]);
+
+  const handleUpgrade = async () => {
+    setIsUpgrading(true);
+    try {
+      const result = await clubsAPI.upgradeClub(token, club.id);
+      setDetail((prev) => prev ? { ...prev, plan: result.plan as 'premium', planExpiresAt: result.planExpiresAt } : prev);
+      onClubUpdated({ ...club, plan: result.plan as 'premium', planExpiresAt: result.planExpiresAt });
+      toast({ title: '¡Club actualizado a Premium!', description: 'Ahora tenés acceso a todas las funciones.' });
+    } catch (err: any) {
+      toast({ title: 'Error', description: err.message, variant: 'destructive' });
+    } finally {
+      setIsUpgrading(false);
+    }
+  };
 
   const handleSaveBook = async () => {
     if (!detail) return;
@@ -100,7 +146,11 @@ const ClubDetailSheet: React.FC<Props> = ({ club, token, userId, onClose, onClub
       setEditingBook(false);
       toast({ title: 'Libro actual actualizado' });
     } catch (err: any) {
-      toast({ title: 'Error', description: err.message, variant: 'destructive' });
+      if (err instanceof ApiError && err.code === 'PREMIUM_REQUIRED') {
+        toast({ title: 'Plan Premium requerido', description: err.message, variant: 'destructive' });
+      } else {
+        toast({ title: 'Error', description: err.message, variant: 'destructive' });
+      }
     } finally {
       setIsSavingBook(false);
     }
@@ -149,7 +199,11 @@ const ClubDetailSheet: React.FC<Props> = ({ club, token, userId, onClose, onClub
       setShowMeetingForm(false);
       toast({ title: 'Reunión agendada' });
     } catch (err: any) {
-      toast({ title: 'Error', description: err.message, variant: 'destructive' });
+      if (err instanceof ApiError && err.code === 'PREMIUM_REQUIRED') {
+        toast({ title: 'Plan Premium requerido', description: err.message, variant: 'destructive' });
+      } else {
+        toast({ title: 'Error', description: err.message, variant: 'destructive' });
+      }
     } finally {
       setIsAddingMeeting(false);
     }
@@ -204,7 +258,11 @@ const ClubDetailSheet: React.FC<Props> = ({ club, token, userId, onClose, onClub
       setDetail((prev) => prev ? { ...prev, posts: [post, ...prev.posts] } : prev);
       setPostContent('');
     } catch (err: any) {
-      toast({ title: 'Error', description: err.message, variant: 'destructive' });
+      if (err instanceof ApiError && err.code === 'PREMIUM_REQUIRED') {
+        toast({ title: 'Plan Premium requerido', description: err.message, variant: 'destructive' });
+      } else {
+        toast({ title: 'Error', description: err.message, variant: 'destructive' });
+      }
     } finally {
       setIsPosting(false);
     }
@@ -226,7 +284,15 @@ const ClubDetailSheet: React.FC<Props> = ({ club, token, userId, onClose, onClub
     <Sheet open onOpenChange={(open) => { if (!open) onClose(); }}>
       <SheetContent side="right" className="w-full sm:max-w-lg flex flex-col p-0 overflow-hidden">
         <SheetHeader className="px-6 py-5 border-b border-border flex-shrink-0">
-          <SheetTitle className="font-mono text-base text-left leading-snug">{club.nombre}</SheetTitle>
+          <div className="flex items-center gap-2">
+            <SheetTitle className="font-mono text-base text-left leading-snug">{club.nombre}</SheetTitle>
+            {isPremium && (
+              <span className="flex items-center gap-1 text-xs font-mono px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200 flex-shrink-0">
+                <Crown className="h-3 w-3" />
+                Premium
+              </span>
+            )}
+          </div>
           <div className="flex flex-col gap-1 mt-1">
             {club.descripcion && <p className="text-xs text-muted-foreground">{club.descripcion}</p>}
             <div className="flex items-center gap-3 text-xs text-muted-foreground mt-0.5">
@@ -275,7 +341,7 @@ const ClubDetailSheet: React.FC<Props> = ({ club, token, userId, onClose, onClub
                   <BookOpen className="h-3.5 w-3.5" />
                   Libro actual
                 </h3>
-                {isClubAdmin && !editingBook && (
+                {isClubAdmin && !editingBook && isPremium && (
                   <button
                     onClick={() => {
                       setBookTitle(detail.currentBookTitle ?? '');
@@ -290,7 +356,9 @@ const ClubDetailSheet: React.FC<Props> = ({ club, token, userId, onClose, onClub
                 )}
               </div>
 
-              {editingBook ? (
+              {!isPremium ? (
+                <UpgradeBanner isAdmin={isClubAdmin} onUpgrade={handleUpgrade} isUpgrading={isUpgrading} />
+              ) : editingBook ? (
                 <div className="space-y-3 bg-card border border-border rounded-xl p-4">
                   <div className="space-y-2">
                     <div className="space-y-1">
@@ -391,7 +459,7 @@ const ClubDetailSheet: React.FC<Props> = ({ club, token, userId, onClose, onClub
                   <Calendar className="h-3.5 w-3.5" />
                   Próximas reuniones
                 </h3>
-                {isClubAdmin && (
+                {isClubAdmin && isPremium && (
                   <button
                     onClick={() => setShowMeetingForm((v) => !v)}
                     className="text-xs text-muted-foreground hover:text-foreground transition-colors"
@@ -401,90 +469,96 @@ const ClubDetailSheet: React.FC<Props> = ({ club, token, userId, onClose, onClub
                 )}
               </div>
 
-              <AnimatePresence>
-                {showMeetingForm && (
-                  <motion.form
-                    initial={{ opacity: 0, y: -6 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -6 }}
-                    onSubmit={handleAddMeeting}
-                    className="bg-card border border-border rounded-xl p-4 space-y-3"
-                  >
-                    <div className="space-y-2">
-                      <div className="space-y-1">
-                        <Label className="text-xs text-muted-foreground font-mono">Título *</Label>
-                        <Input
-                          value={meetTitulo}
-                          onChange={(e) => setMeetTitulo(e.target.value)}
-                          placeholder="Ej: Encuentro mensual"
-                          className="bg-background text-sm"
-                        />
-                      </div>
-                      <div className="space-y-1">
-                        <Label className="text-xs text-muted-foreground font-mono">Fecha y hora *</Label>
-                        <Input
-                          type="datetime-local"
-                          value={meetFecha}
-                          onChange={(e) => setMeetFecha(e.target.value)}
-                          className="bg-background text-sm"
-                        />
-                      </div>
-                      <div className="space-y-1">
-                        <Label className="text-xs text-muted-foreground font-mono">Lugar</Label>
-                        <Input
-                          value={meetUbicacion}
-                          onChange={(e) => setMeetUbicacion(e.target.value)}
-                          placeholder="Ej: Café La Paloma, Palermo"
-                          className="bg-background text-sm"
-                        />
-                      </div>
-                    </div>
-                    <Button
-                      type="submit"
-                      disabled={isAddingMeeting || !meetTitulo.trim() || !meetFecha}
-                      size="sm"
-                      className="bg-accent text-accent-foreground hover:bg-accent/90 text-xs h-8"
-                    >
-                      {isAddingMeeting ? 'Agendando...' : 'Agendar reunión'}
-                    </Button>
-                  </motion.form>
-                )}
-              </AnimatePresence>
-
-              {detail.meetings.length === 0 ? (
-                <p className="text-xs text-muted-foreground">No hay reuniones próximas agendadas.</p>
+              {!isPremium ? (
+                <p className="text-xs text-muted-foreground">Disponible en plan Premium.</p>
               ) : (
-                <div className="space-y-2">
-                  {detail.meetings.map((m: ClubMeeting) => (
-                    <div
-                      key={m.id}
-                      className="flex items-start gap-3 bg-card border border-border rounded-xl px-4 py-3"
-                    >
-                      <div className="flex-1 min-w-0 space-y-0.5">
-                        <p className="font-mono text-sm font-bold text-foreground">{m.titulo}</p>
-                        <p className="text-xs text-muted-foreground">{fmtDate(m.fecha)}</p>
-                        {m.ubicacion && (
-                          <p className="text-xs text-muted-foreground flex items-center gap-1">
-                            <MapPin className="h-3 w-3" />
-                            {m.ubicacion}
-                          </p>
-                        )}
-                        {m.descripcion && (
-                          <p className="text-xs text-muted-foreground mt-1">{m.descripcion}</p>
-                        )}
-                      </div>
-                      {isClubAdmin && (
-                        <button
-                          onClick={() => handleDeleteMeeting(m.id)}
-                          disabled={deletingMeetingId === m.id}
-                          className="text-muted-foreground hover:text-destructive transition-colors flex-shrink-0 p-0.5 mt-0.5"
+                <>
+                  <AnimatePresence>
+                    {showMeetingForm && (
+                      <motion.form
+                        initial={{ opacity: 0, y: -6 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -6 }}
+                        onSubmit={handleAddMeeting}
+                        className="bg-card border border-border rounded-xl p-4 space-y-3"
+                      >
+                        <div className="space-y-2">
+                          <div className="space-y-1">
+                            <Label className="text-xs text-muted-foreground font-mono">Título *</Label>
+                            <Input
+                              value={meetTitulo}
+                              onChange={(e) => setMeetTitulo(e.target.value)}
+                              placeholder="Ej: Encuentro mensual"
+                              className="bg-background text-sm"
+                            />
+                          </div>
+                          <div className="space-y-1">
+                            <Label className="text-xs text-muted-foreground font-mono">Fecha y hora *</Label>
+                            <Input
+                              type="datetime-local"
+                              value={meetFecha}
+                              onChange={(e) => setMeetFecha(e.target.value)}
+                              className="bg-background text-sm"
+                            />
+                          </div>
+                          <div className="space-y-1">
+                            <Label className="text-xs text-muted-foreground font-mono">Lugar</Label>
+                            <Input
+                              value={meetUbicacion}
+                              onChange={(e) => setMeetUbicacion(e.target.value)}
+                              placeholder="Ej: Café La Paloma, Palermo"
+                              className="bg-background text-sm"
+                            />
+                          </div>
+                        </div>
+                        <Button
+                          type="submit"
+                          disabled={isAddingMeeting || !meetTitulo.trim() || !meetFecha}
+                          size="sm"
+                          className="bg-accent text-accent-foreground hover:bg-accent/90 text-xs h-8"
                         >
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </button>
-                      )}
+                          {isAddingMeeting ? 'Agendando...' : 'Agendar reunión'}
+                        </Button>
+                      </motion.form>
+                    )}
+                  </AnimatePresence>
+
+                  {detail.meetings.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">No hay reuniones próximas agendadas.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {detail.meetings.map((m: ClubMeeting) => (
+                        <div
+                          key={m.id}
+                          className="flex items-start gap-3 bg-card border border-border rounded-xl px-4 py-3"
+                        >
+                          <div className="flex-1 min-w-0 space-y-0.5">
+                            <p className="font-mono text-sm font-bold text-foreground">{m.titulo}</p>
+                            <p className="text-xs text-muted-foreground">{fmtDate(m.fecha)}</p>
+                            {m.ubicacion && (
+                              <p className="text-xs text-muted-foreground flex items-center gap-1">
+                                <MapPin className="h-3 w-3" />
+                                {m.ubicacion}
+                              </p>
+                            )}
+                            {m.descripcion && (
+                              <p className="text-xs text-muted-foreground mt-1">{m.descripcion}</p>
+                            )}
+                          </div>
+                          {isClubAdmin && (
+                            <button
+                              onClick={() => handleDeleteMeeting(m.id)}
+                              disabled={deletingMeetingId === m.id}
+                              className="text-muted-foreground hover:text-destructive transition-colors flex-shrink-0 p-0.5 mt-0.5"
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                          )}
+                        </div>
+                      ))}
                     </div>
-                  ))}
-                </div>
+                  )}
+                </>
               )}
             </section>
 
@@ -497,56 +571,62 @@ const ClubDetailSheet: React.FC<Props> = ({ club, token, userId, onClose, onClub
                 Foro del club
               </h3>
 
-              <form onSubmit={handlePost} className="flex gap-2 items-end">
-                <Textarea
-                  value={postContent}
-                  onChange={(e) => setPostContent(e.target.value)}
-                  placeholder="Escribí algo para el club..."
-                  className="bg-card text-sm resize-none"
-                  rows={2}
-                  maxLength={1000}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                      e.preventDefault();
-                      if (postContent.trim()) handlePost(e as unknown as React.FormEvent);
-                    }
-                  }}
-                />
-                <Button
-                  type="submit"
-                  size="icon"
-                  disabled={isPosting || !postContent.trim()}
-                  className="h-9 w-9 flex-shrink-0 bg-accent text-accent-foreground hover:bg-accent/90"
-                >
-                  <Send className="h-3.5 w-3.5" />
-                </Button>
-              </form>
-
-              {detail.posts.length === 0 ? (
-                <p className="text-xs text-muted-foreground">Nadie ha publicado todavía. ¡Sé el primero!</p>
+              {!isPremium ? (
+                <p className="text-xs text-muted-foreground">Disponible en plan Premium.</p>
               ) : (
-                <div className="space-y-2">
-                  {detail.posts.map((p: ClubPost) => (
-                    <div key={p.id} className="bg-card border border-border rounded-xl px-4 py-3 space-y-1">
-                      <div className="flex items-center justify-between gap-2">
-                        <div className="flex items-center gap-2">
-                          <span className="font-mono text-xs font-bold text-foreground">{p.autorUsername}</span>
-                          <span className="text-xs text-muted-foreground">{timeAgo(p.createdAt)}</span>
+                <>
+                  <form onSubmit={handlePost} className="flex gap-2 items-end">
+                    <Textarea
+                      value={postContent}
+                      onChange={(e) => setPostContent(e.target.value)}
+                      placeholder="Escribí algo para el club..."
+                      className="bg-card text-sm resize-none"
+                      rows={2}
+                      maxLength={1000}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault();
+                          if (postContent.trim()) handlePost(e as unknown as React.FormEvent);
+                        }
+                      }}
+                    />
+                    <Button
+                      type="submit"
+                      size="icon"
+                      disabled={isPosting || !postContent.trim()}
+                      className="h-9 w-9 flex-shrink-0 bg-accent text-accent-foreground hover:bg-accent/90"
+                    >
+                      <Send className="h-3.5 w-3.5" />
+                    </Button>
+                  </form>
+
+                  {detail.posts.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">Nadie ha publicado todavía. ¡Sé el primero!</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {detail.posts.map((p: ClubPost) => (
+                        <div key={p.id} className="bg-card border border-border rounded-xl px-4 py-3 space-y-1">
+                          <div className="flex items-center justify-between gap-2">
+                            <div className="flex items-center gap-2">
+                              <span className="font-mono text-xs font-bold text-foreground">{p.autorUsername}</span>
+                              <span className="text-xs text-muted-foreground">{timeAgo(p.createdAt)}</span>
+                            </div>
+                            {(isClubAdmin || p.autorId === userId) && (
+                              <button
+                                onClick={() => handleDeletePost(p.id)}
+                                disabled={deletingPostId === p.id}
+                                className="text-muted-foreground hover:text-destructive transition-colors flex-shrink-0 p-0.5"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </button>
+                            )}
+                          </div>
+                          <p className="text-sm text-foreground whitespace-pre-wrap break-words">{p.contenido}</p>
                         </div>
-                        {(isClubAdmin || p.autorId === userId) && (
-                          <button
-                            onClick={() => handleDeletePost(p.id)}
-                            disabled={deletingPostId === p.id}
-                            className="text-muted-foreground hover:text-destructive transition-colors flex-shrink-0 p-0.5"
-                          >
-                            <Trash2 className="h-3.5 w-3.5" />
-                          </button>
-                        )}
-                      </div>
-                      <p className="text-sm text-foreground whitespace-pre-wrap break-words">{p.contenido}</p>
+                      ))}
                     </div>
-                  ))}
-                </div>
+                  )}
+                </>
               )}
             </section>
 

--- a/librosclub-frontend/src/components/ClubesTab.tsx
+++ b/librosclub-frontend/src/components/ClubesTab.tsx
@@ -6,7 +6,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { motion, AnimatePresence } from 'framer-motion';
-import { MapPin, Users, Plus, BookOpen, X, Check, ChevronRight, Navigation } from 'lucide-react';
+import { MapPin, Users, Plus, BookOpen, X, Check, ChevronRight, Navigation, Crown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import ClubDetailSheet from './ClubDetailSheet';
 
@@ -44,16 +44,19 @@ const ClubCard: React.FC<{
         <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
           <BookOpen className="h-5 w-5 text-primary" />
         </div>
-        {isMember && (
-          <span className={cn(
-            'text-xs font-mono px-2.5 py-1 rounded-full flex-shrink-0',
-            isClubAdmin
-              ? 'bg-accent/20 text-accent-foreground'
-              : 'bg-primary/10 text-primary'
-          )}>
-            {isClubAdmin ? 'Admin' : 'Miembro'}
-          </span>
-        )}
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          {club.plan === 'premium' && (
+            <span className="flex items-center gap-1 text-xs font-mono px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200">
+              <Crown className="h-3 w-3" />
+              Premium
+            </span>
+          )}
+          {isMember && (
+            <span className="text-xs font-mono px-2.5 py-1 rounded-full bg-primary/10 text-primary border border-primary/20">
+              {isClubAdmin ? 'Admin' : 'Miembro'}
+            </span>
+          )}
+        </div>
       </div>
 
       <div className="flex-1 space-y-1">

--- a/librosclub-frontend/src/components/Dashboard.tsx
+++ b/librosclub-frontend/src/components/Dashboard.tsx
@@ -31,12 +31,14 @@ import {
   XCircle,
   Clock,
   MessageCircle,
+  Crown,
 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { jwtDecode } from 'jwt-decode';
 import { motion, AnimatePresence } from 'framer-motion';
 import { cn } from '@/lib/utils';
 import AuthModal from './AuthModal';
+import PremiumUpgradeModal from './PremiumUpgradeModal';
 
 type TabKey = 'feed' | 'search' | 'all' | 'clubs' | 'nearby' | 'admin';
 
@@ -117,9 +119,10 @@ const Dashboard: React.FC = () => {
     setAuthModalOpen(true);
   };
 
-  const { token, logout } = useAuth();
+  const { token, logout, isPremium } = useAuth();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
 
   const decoded = token ? jwtDecode<{ role: string; userId: number; username: string }>(token) : null;
   const isAdmin = decoded?.role === 'admin';
@@ -671,9 +674,32 @@ const Dashboard: React.FC = () => {
             <div className="p-4 border-t border-sidebar-border">
               {token ? (
                 <>
-                  <p className="text-xs text-sidebar-foreground/40 font-mono truncate px-1 mb-2">
-                    {decoded?.username}
-                  </p>
+                  <div className="flex items-center gap-2 px-1 mb-2">
+                    <p className="text-xs text-sidebar-foreground/40 font-mono truncate flex-1">
+                      {decoded?.username}
+                    </p>
+                    {isPremium ? (
+                      <span className="flex items-center gap-0.5 text-xs font-mono px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200 flex-shrink-0">
+                        <Crown className="h-2.5 w-2.5" />
+                        Pro
+                      </span>
+                    ) : (
+                      <span className="text-xs font-mono px-1.5 py-0.5 rounded-full bg-sidebar-foreground/10 text-sidebar-foreground/60 border border-sidebar-foreground/20 flex-shrink-0">
+                        Free
+                      </span>
+                    )}
+                  </div>
+                  {!isPremium && (
+                    <Button
+                      onClick={() => setUpgradeModalOpen(true)}
+                      variant="ghost"
+                      size="sm"
+                      className="w-full justify-start text-amber-600 hover:text-amber-700 hover:bg-amber-50 text-xs mb-1"
+                    >
+                      <Crown className="h-3.5 w-3.5 mr-2" />
+                      Activar Premium
+                    </Button>
+                  )}
                   <Button
                     onClick={handleLogout}
                     variant="ghost"
@@ -732,7 +758,7 @@ const Dashboard: React.FC = () => {
 
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             {isAdmin && (
-              <span className="bg-accent/15 text-accent text-xs font-medium px-2.5 py-1 rounded-full">
+              <span className="bg-primary/10 text-primary border border-primary/20 text-xs font-mono font-medium px-2.5 py-1 rounded-full">
                 Admin
               </span>
             )}
@@ -813,6 +839,7 @@ const Dashboard: React.FC = () => {
         onClose={() => setAuthModalOpen(false)}
         defaultMode={authModalMode}
       />
+      {upgradeModalOpen && <PremiumUpgradeModal onClose={() => setUpgradeModalOpen(false)} />}
       {chatRequest && token && decoded && (
         <RequestChatModal
           requestId={chatRequest.id}

--- a/librosclub-frontend/src/components/LandingPage.tsx
+++ b/librosclub-frontend/src/components/LandingPage.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { BookOpen, Rss, Search, Library, ArrowRight, Users, MapPin, ArrowLeftRight } from 'lucide-react';
+import { BookOpen, Rss, Search, Library, ArrowRight, Users, MapPin, ArrowLeftRight, Check, Crown, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { motion } from 'framer-motion';
 import AuthModal from './AuthModal';
+import PremiumUpgradeModal from './PremiumUpgradeModal';
+import { useAuth } from '../contexts/AuthContext';
 
 const features = [
   {
@@ -40,8 +42,10 @@ const features = [
 
 const LandingPage: React.FC = () => {
   const navigate = useNavigate();
+  const { isAuthenticated, isPremium, username } = useAuth();
   const [authOpen, setAuthOpen] = useState(false);
   const [authMode, setAuthMode] = useState<'login' | 'register'>('register');
+  const [paymentOpen, setPaymentOpen] = useState(false);
 
   const openAuth = (mode: 'login' | 'register') => {
     setAuthMode(mode);
@@ -90,14 +94,16 @@ const LandingPage: React.FC = () => {
               Explorar la plataforma
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
-            <Button
-              size="lg"
-              variant="outline"
-              className="border-sidebar-foreground/30 text-sidebar-foreground bg-transparent hover:bg-sidebar-accent/50 hover:text-sidebar-foreground font-mono"
-              onClick={() => openAuth('register')}
-            >
-              Crear cuenta gratis
-            </Button>
+            {!isAuthenticated && (
+              <Button
+                size="lg"
+                variant="outline"
+                className="border-sidebar-foreground/30 text-sidebar-foreground bg-transparent hover:bg-sidebar-accent/50 hover:text-sidebar-foreground font-mono"
+                onClick={() => openAuth('register')}
+              >
+                Crear cuenta gratis
+              </Button>
+            )}
           </motion.div>
 
           <motion.p
@@ -106,13 +112,27 @@ const LandingPage: React.FC = () => {
             animate={{ opacity: 1 }}
             transition={{ duration: 0.5, delay: 0.3 }}
           >
-            ¿Ya tenés cuenta?{' '}
-            <button
-              onClick={() => openAuth('login')}
-              className="underline underline-offset-2 hover:text-sidebar-foreground/70 transition-colors"
-            >
-              Iniciá sesión
-            </button>
+            {isAuthenticated ? (
+              <>
+                Hola, <span className="text-sidebar-foreground/60">{username}</span>.{' '}
+                <button
+                  onClick={() => navigate('/app')}
+                  className="underline underline-offset-2 hover:text-sidebar-foreground/70 transition-colors"
+                >
+                  Ir a la plataforma
+                </button>
+              </>
+            ) : (
+              <>
+                ¿Ya tenés cuenta?{' '}
+                <button
+                  onClick={() => openAuth('login')}
+                  className="underline underline-offset-2 hover:text-sidebar-foreground/70 transition-colors"
+                >
+                  Iniciá sesión
+                </button>
+              </>
+            )}
           </motion.p>
         </div>
       </section>
@@ -161,6 +181,143 @@ const LandingPage: React.FC = () => {
         </div>
       </section>
 
+      {/* Pricing */}
+      <section className="bg-muted/40 border-y border-border py-20">
+        <div className="max-w-5xl mx-auto px-6">
+          <div className="mb-12">
+            <h2 className="font-mono text-2xl sm:text-3xl font-bold text-foreground">
+              Planes
+            </h2>
+            <p className="mt-2 text-muted-foreground">
+              Empezá gratis. Desbloqueá todo con Premium.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {/* Free */}
+            <motion.div
+              className="bg-card border border-border rounded-xl p-6 flex flex-col gap-4"
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.35, delay: 0.05 }}
+            >
+              <div>
+                <p className="font-mono text-xs text-muted-foreground uppercase tracking-widest mb-1">Gratis</p>
+                <p className="font-mono text-3xl font-bold text-foreground">$0</p>
+                <p className="text-xs text-muted-foreground mt-1">Para siempre</p>
+              </div>
+              <ul className="flex flex-col gap-2.5 text-sm flex-1">
+                {[
+                  'Feed de novedades por género',
+                  'Búsqueda de libros',
+                  'Catálogo de la comunidad',
+                  'Intercambios P2P',
+                  'Unirse a clubes de lectura',
+                  'Hasta 10 miembros por club',
+                ].map((item) => (
+                  <li key={item} className="flex items-start gap-2 text-foreground">
+                    <Check className="h-4 w-4 text-primary flex-shrink-0 mt-0.5" />
+                    {item}
+                  </li>
+                ))}
+                {[
+                  'Libro actual del club',
+                  'Reuniones del club',
+                  'Foro del club',
+                ].map((item) => (
+                  <li key={item} className="flex items-start gap-2 text-muted-foreground/50">
+                    <X className="h-4 w-4 flex-shrink-0 mt-0.5" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+              <Button
+                variant="outline"
+                className="w-full font-mono"
+                onClick={() => isAuthenticated ? navigate('/app') : openAuth('register')}
+              >
+                {isAuthenticated ? 'Ir a la plataforma' : 'Empezar gratis'}
+              </Button>
+            </motion.div>
+
+            {/* Premium */}
+            <motion.div
+              className="bg-card border-2 border-amber-400 rounded-xl p-6 flex flex-col gap-4 relative"
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.35, delay: 0.12 }}
+            >
+              <div className="absolute top-4 right-4">
+                <span className="flex items-center gap-1 text-xs font-mono px-2.5 py-1 rounded-full bg-amber-100 text-amber-700 border border-amber-200">
+                  <Crown className="h-3 w-3" />
+                  Premium
+                </span>
+              </div>
+              <div>
+                <p className="font-mono text-xs text-muted-foreground uppercase tracking-widest mb-1">Premium</p>
+                <p className="font-mono text-3xl font-bold text-foreground">
+                  $5<span className="text-base font-normal text-muted-foreground">/mes</span>
+                </p>
+                <p className="text-xs text-muted-foreground mt-1">Por club</p>
+              </div>
+              <ul className="flex flex-col gap-2.5 text-sm flex-1">
+                {[
+                  'Todo lo del plan Gratis',
+                  'Sin límite de miembros',
+                  'Libro actual del club',
+                  'Reuniones y agenda del club',
+                  'Foro asíncrono del club',
+                ].map((item) => (
+                  <li key={item} className="flex items-start gap-2 text-foreground">
+                    <Check className="h-4 w-4 text-amber-600 flex-shrink-0 mt-0.5" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+
+              {/* CTA según estado de auth */}
+              {isPremium ? (
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-center gap-2 py-2 rounded-lg bg-amber-50 border border-amber-200">
+                    <Crown className="h-4 w-4 text-amber-600" />
+                    <span className="text-sm font-mono font-bold text-amber-700">Ya sos Premium</span>
+                  </div>
+                  <Button variant="outline" className="w-full font-mono text-xs" onClick={() => navigate('/app')}>
+                    Ir a la plataforma
+                  </Button>
+                </div>
+              ) : isAuthenticated ? (
+                <Button
+                  className="w-full font-mono bg-amber-600 hover:bg-amber-700 text-white"
+                  onClick={() => setPaymentOpen(true)}
+                >
+                  <Crown className="h-3.5 w-3.5 mr-1.5" />
+                  Activar Premium
+                </Button>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  <Button
+                    className="w-full font-mono bg-amber-600 hover:bg-amber-700 text-white"
+                    onClick={() => openAuth('login')}
+                  >
+                    Iniciá sesión para activar
+                  </Button>
+                  <p className="text-center text-xs text-muted-foreground">
+                    ¿No tenés cuenta?{' '}
+                    <button
+                      className="underline underline-offset-2 hover:text-foreground transition-colors"
+                      onClick={() => openAuth('register')}
+                    >
+                      Registrate
+                    </button>
+                  </p>
+                </div>
+              )}
+            </motion.div>
+          </div>
+        </div>
+      </section>
+
       {/* Footer */}
       <footer className="border-t border-border py-8 px-6">
         <div className="max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-3 text-sm text-muted-foreground font-mono">
@@ -178,6 +335,8 @@ const LandingPage: React.FC = () => {
         defaultMode={authMode}
         onSuccess={() => navigate('/app')}
       />
+
+      {paymentOpen && <PremiumUpgradeModal onClose={() => setPaymentOpen(false)} />}
     </div>
   );
 };

--- a/librosclub-frontend/src/components/PremiumUpgradeModal.tsx
+++ b/librosclub-frontend/src/components/PremiumUpgradeModal.tsx
@@ -1,0 +1,148 @@
+import React, { useState } from 'react';
+import { Crown, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { motion } from 'framer-motion';
+import { authAPI } from '../utils/api';
+import { useAuth } from '../contexts/AuthContext';
+import { useToast } from '@/hooks/use-toast';
+
+interface Props {
+  onClose: () => void;
+}
+
+const PremiumUpgradeModal: React.FC<Props> = ({ onClose }) => {
+  const { token, login } = useAuth();
+  const { toast } = useToast();
+  const [cardName, setCardName] = useState('');
+  const [cardNumber, setCardNumber] = useState('');
+  const [expiry, setExpiry] = useState('');
+  const [cvv, setCvv] = useState('');
+  const [isPaying, setIsPaying] = useState(false);
+  const [paid, setPaid] = useState(false);
+
+  const formatCardNumber = (value: string) =>
+    value.replace(/\D/g, '').slice(0, 16).replace(/(.{4})/g, '$1 ').trim();
+
+  const formatExpiry = (value: string) => {
+    const digits = value.replace(/\D/g, '').slice(0, 4);
+    return digits.length >= 3 ? digits.slice(0, 2) + '/' + digits.slice(2) : digits;
+  };
+
+  const handlePay = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token) return;
+    setIsPaying(true);
+    try {
+      const result = await authAPI.upgradeUser(token);
+      login(result.token);
+      setPaid(true);
+    } catch {
+      toast({ title: 'Error al procesar el pago', variant: 'destructive' });
+    } finally {
+      setIsPaying(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm px-4">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 8 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        className="bg-card border border-border rounded-2xl p-6 w-full max-w-sm shadow-xl"
+      >
+        {paid ? (
+          <div className="text-center py-6 space-y-4">
+            <div className="h-14 w-14 rounded-full bg-amber-100 flex items-center justify-center mx-auto">
+              <Crown className="h-7 w-7 text-amber-600" />
+            </div>
+            <div>
+              <p className="font-mono font-bold text-foreground">¡Plan Premium activado!</p>
+              <p className="text-sm text-muted-foreground mt-1">Tus funciones quedan disponibles por 30 días.</p>
+            </div>
+            <Button className="w-full font-mono bg-amber-600 hover:bg-amber-700 text-white" onClick={onClose}>
+              Cerrar
+            </Button>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center justify-between mb-5">
+              <div className="flex items-center gap-2">
+                <Crown className="h-4 w-4 text-amber-600" />
+                <h3 className="font-mono font-bold text-sm text-foreground">Activar Premium</h3>
+              </div>
+              <button onClick={onClose} className="text-muted-foreground hover:text-foreground transition-colors">
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2.5 mb-5 flex items-center justify-between">
+              <span className="text-xs text-amber-700 font-mono">Plan Premium · 30 días</span>
+              <span className="text-sm font-bold text-amber-800 font-mono">$5</span>
+            </div>
+
+            <form onSubmit={handlePay} className="space-y-3.5">
+              <div className="space-y-1.5">
+                <Label className="text-xs text-muted-foreground font-mono">Nombre en la tarjeta</Label>
+                <Input
+                  placeholder="JUAN PEREZ"
+                  value={cardName}
+                  onChange={(e) => setCardName(e.target.value.toUpperCase())}
+                  className="bg-background font-mono text-sm"
+                  required
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs text-muted-foreground font-mono">Número de tarjeta</Label>
+                <Input
+                  placeholder="0000 0000 0000 0000"
+                  value={cardNumber}
+                  onChange={(e) => setCardNumber(formatCardNumber(e.target.value))}
+                  className="bg-background font-mono text-sm tracking-widest"
+                  required
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label className="text-xs text-muted-foreground font-mono">Vencimiento</Label>
+                  <Input
+                    placeholder="MM/AA"
+                    value={expiry}
+                    onChange={(e) => setExpiry(formatExpiry(e.target.value))}
+                    className="bg-background font-mono text-sm"
+                    required
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label className="text-xs text-muted-foreground font-mono">CVV</Label>
+                  <Input
+                    placeholder="000"
+                    value={cvv}
+                    onChange={(e) => setCvv(e.target.value.replace(/\D/g, '').slice(0, 4))}
+                    className="bg-background font-mono text-sm"
+                    required
+                  />
+                </div>
+              </div>
+              <Button
+                type="submit"
+                disabled={isPaying}
+                className="w-full font-mono bg-amber-600 hover:bg-amber-700 text-white mt-1"
+              >
+                <Crown className="h-3.5 w-3.5 mr-1.5" />
+                {isPaying ? 'Procesando...' : 'Pagar $5'}
+              </Button>
+            </form>
+
+            <p className="text-center text-xs text-muted-foreground/50 mt-4 font-mono">
+              * Entorno de demostración — no se realiza ningún cobro real
+            </p>
+          </>
+        )}
+      </motion.div>
+    </div>
+  );
+};
+
+export default PremiumUpgradeModal;

--- a/librosclub-frontend/src/contexts/AuthContext.tsx
+++ b/librosclub-frontend/src/contexts/AuthContext.tsx
@@ -1,13 +1,32 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import { jwtDecode } from 'jwt-decode';
+
+interface DecodedToken {
+  userId: number;
+  username: string;
+  role: string;
+  plan?: 'free' | 'premium';
+}
 
 interface AuthContextType {
   token: string | null;
   isAuthenticated: boolean;
+  username: string | null;
+  plan: 'free' | 'premium' | null;
+  isPremium: boolean;
   login: (token: string) => void;
   logout: () => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+function decodeToken(token: string): DecodedToken | null {
+  try {
+    return jwtDecode<DecodedToken>(token);
+  } catch {
+    return null;
+  }
+}
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [token, setToken] = useState<string | null>(null);
@@ -17,7 +36,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     if (storedToken) setToken(storedToken);
   }, []);
 
-  // Cerrar sesión automáticamente cuando el backend reporta token expirado
   useEffect(() => {
     const handler = () => {
       localStorage.removeItem('libros_token');
@@ -37,12 +55,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setToken(null);
   };
 
+  const decoded = token ? decodeToken(token) : null;
+  const plan = decoded?.plan ?? (token ? 'free' : null);
+  const isPremium = plan === 'premium';
+
   return (
     <AuthContext.Provider value={{
       token,
       isAuthenticated: !!token,
+      username: decoded?.username ?? null,
+      plan,
+      isPremium,
       login,
-      logout
+      logout,
     }}>
       {children}
     </AuthContext.Provider>

--- a/librosclub-frontend/src/utils/api.ts
+++ b/librosclub-frontend/src/utils/api.ts
@@ -1,5 +1,14 @@
 const API_BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:3000/api';
 
+export class ApiError extends Error {
+  code?: string;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.code = code;
+  }
+}
+
 // Dispara un evento global cuando el backend responde 401 con expired:true
 async function handleResponse(res: Response): Promise<Response> {
   if (res.status === 401) {
@@ -54,6 +63,18 @@ export const authAPI = {
     if (!response.ok) {
       const body = await response.json().catch(() => ({}));
       throw new Error((body as any).message ?? 'Error al registrarse.');
+    }
+    return response.json();
+  },
+
+  upgradeUser: async (token: string): Promise<LoginResponse> => {
+    const response = await fetch(`${API_BASE_URL}/auth/upgrade`, {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      throw new ApiError((body as any).message ?? 'Error al actualizar el plan.');
     }
     return response.json();
   },
@@ -290,6 +311,8 @@ export interface Club {
   currentBookAuthor?: string | null;
   currentBookCoverUrl?: string | null;
   distanceKm?: number;
+  plan?: 'free' | 'premium';
+  planExpiresAt?: string | null;
 }
 
 export interface ClubMeeting {
@@ -348,7 +371,7 @@ export const clubsAPI = {
     }));
     if (!r.ok) {
       const body = await r.json().catch(() => ({}));
-      throw new Error(body.message ?? 'Error al unirse al club.');
+      throw new ApiError(body.message ?? 'Error al unirse al club.', body.code);
     }
   },
 
@@ -382,7 +405,10 @@ export const clubsAPI = {
       headers: authHeaders(token),
       body: JSON.stringify(payload),
     }));
-    if (!r.ok) throw new Error('Error al actualizar el libro actual.');
+    if (!r.ok) {
+      const body = await r.json().catch(() => ({}));
+      throw new ApiError(body.message ?? 'Error al actualizar el libro actual.', body.code);
+    }
   },
 
   addMeeting: async (
@@ -397,7 +423,7 @@ export const clubsAPI = {
     }));
     if (!r.ok) {
       const body = await r.json().catch(() => ({}));
-      throw new Error(body.message ?? 'Error al agregar reunión.');
+      throw new ApiError(body.message ?? 'Error al agregar reunión.', body.code);
     }
     return r.json();
   },
@@ -407,7 +433,10 @@ export const clubsAPI = {
       method: 'DELETE',
       headers: authHeaders(token),
     }));
-    if (!r.ok) throw new Error('Error al eliminar reunión.');
+    if (!r.ok) {
+      const body = await r.json().catch(() => ({}));
+      throw new ApiError(body.message ?? 'Error al eliminar reunión.', body.code);
+    }
   },
 
   createPost: async (token: string, clubId: number, contenido: string): Promise<ClubPost> => {
@@ -418,7 +447,7 @@ export const clubsAPI = {
     }));
     if (!r.ok) {
       const body = await r.json().catch(() => ({}));
-      throw new Error(body.message ?? 'Error al publicar mensaje.');
+      throw new ApiError(body.message ?? 'Error al publicar mensaje.', body.code);
     }
     return r.json();
   },
@@ -428,7 +457,10 @@ export const clubsAPI = {
       method: 'DELETE',
       headers: authHeaders(token),
     }));
-    if (!r.ok) throw new Error('Error al eliminar mensaje.');
+    if (!r.ok) {
+      const body = await r.json().catch(() => ({}));
+      throw new ApiError(body.message ?? 'Error al eliminar mensaje.', body.code);
+    }
   },
 
   getNearbyClubs: async (lat: number, lng: number, radius: number, token: string | null): Promise<Club[]> => {
@@ -453,6 +485,18 @@ export const clubsAPI = {
       body: JSON.stringify(payload),
     }));
     if (!r.ok) throw new Error('Error al actualizar la ubicación.');
+  },
+
+  upgradeClub: async (token: string, clubId: number): Promise<{ plan: string; planExpiresAt: string }> => {
+    const r = await handleResponse(await fetch(`${API_BASE_URL}/clubs/${clubId}/upgrade`, {
+      method: 'PUT',
+      headers: authHeaders(token),
+    }));
+    if (!r.ok) {
+      const body = await r.json().catch(() => ({}));
+      throw new ApiError(body.message ?? 'Error al actualizar el plan.', body.code);
+    }
+    return r.json();
   },
 };
 


### PR DESCRIPTION
- Implementa el sistema de planes Premium tanto para usuarios como para clubes de lectura, con lógica de expiración a 30 días.
- Agrega el endpoint PUT /api/auth/upgrade para activar el plan Premium de usuario y PUT /api/clubs/:id/upgrade para el plan Premium de club.
- El foro, libro actual y reuniones del club quedan bloqueados para clubes sin plan Premium: el backend devuelve 403 con código PREMIUM_REQUIRED y el frontend muestra un banner de upgrade inline.
- Los clubes gratuitos tienen un límite de 10 miembros; el endpoint joinClub verifica el plan antes de permitir el ingreso.
- El campo plan ahora se incluye en el payload del JWT y en todos los responses de clubes (getClubs, getClubDetail, getNearbyClubs).
- El AuthContext se enriquece con username, plan e isPremium decodificados directamente del token sin requests adicionales.
- Se agrega la clase ApiError con soporte de code para que el frontend pueda distinguir entre errores genéricos y errores de plan.